### PR TITLE
Add terms modal gating login

### DIFF
--- a/src/components/TermsModal.tsx
+++ b/src/components/TermsModal.tsx
@@ -1,0 +1,57 @@
+import { useState } from "react";
+
+interface TermsModalProps {
+  onAccept: () => void;
+}
+
+export function TermsModal({ onAccept }: TermsModalProps) {
+  const [responsibility, setResponsibility] = useState(false);
+  const [useTerms, setUseTerms] = useState(false);
+  const [serviceTerms, setServiceTerms] = useState(false);
+
+  const allChecked = responsibility && useTerms && serviceTerms;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-80">
+      <div className="bg-gray-800 p-6 rounded space-y-4 max-w-md w-full">
+        <h2 className="text-lg font-semibold text-white">Confirmação de Termos</h2>
+        <label className="flex items-start space-x-2 text-gray-200">
+          <input
+            type="checkbox"
+            className="mt-1"
+            checked={responsibility}
+            onChange={(e) => setResponsibility(e.target.checked)}
+          />
+          <span>Isenção de responsabilidades (termo em construção)</span>
+        </label>
+        <label className="flex items-start space-x-2 text-gray-200">
+          <input
+            type="checkbox"
+            className="mt-1"
+            checked={useTerms}
+            onChange={(e) => setUseTerms(e.target.checked)}
+          />
+          <span>Termos de uso (em breve)</span>
+        </label>
+        <label className="flex items-start space-x-2 text-gray-200">
+          <input
+            type="checkbox"
+            className="mt-1"
+            checked={serviceTerms}
+            onChange={(e) => setServiceTerms(e.target.checked)}
+          />
+          <span>Termos de serviço (em breve)</span>
+        </label>
+        <button
+          disabled={!allChecked}
+          onClick={onAccept}
+          className={`w-full py-2 rounded text-white ${
+            allChecked ? "bg-blue-600" : "bg-gray-600 cursor-not-allowed"
+          }`}
+        >
+          Aceitar
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,11 +1,40 @@
 // src/pages/index.tsx
 import { useSession, signIn, signOut } from "next-auth/react";
 import { ThemeEditor } from "@/components/ThemeEditor";
+import { TermsModal } from "@/components/TermsModal";
+import { useEffect, useState } from "react";
 
 export default function Home() {
   const { data: session, status } = useSession();
+  const [termsAccepted, setTermsAccepted] = useState(false);
+  const [showTerms, setShowTerms] = useState(false);
+  const [hydrated, setHydrated] = useState(false);
 
-  if (status === "loading") {
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      setTermsAccepted(localStorage.getItem("termsAccepted") === "true");
+      setHydrated(true);
+    }
+  }, []);
+
+  const handleAccept = () => {
+    localStorage.setItem("termsAccepted", "true");
+    setTermsAccepted(true);
+    setShowTerms(false);
+    if (!session) {
+      signIn("github");
+    }
+  };
+
+  const handleLogin = () => {
+    if (termsAccepted) {
+      signIn("github");
+    } else {
+      setShowTerms(true);
+    }
+  };
+
+  if (status === "loading" || !hydrated) {
     return <p className="p-8 text-center">Carregando…</p>;
   }
 
@@ -13,13 +42,18 @@ export default function Home() {
     return (
       <div className="flex items-center justify-center h-screen bg-gray-100">
         <button
-          onClick={() => signIn("github")}
+          onClick={handleLogin}
           className="px-6 py-3 bg-black text-white rounded-lg"
         >
           Entrar com GitHub
         </button>
+        {showTerms && <TermsModal onAccept={handleAccept} />}
       </div>
     );
+  }
+
+  if (!termsAccepted) {
+    return <TermsModal onAccept={handleAccept} />;
   }
 
   return (


### PR DESCRIPTION
## Summary
- add a modal with 3 confirmation checkboxes
- store acceptance in localStorage and block access to editor until accepted

## Testing
- `npm run lint` *(fails: project prompts for ESLint config)*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6840ce5867c48331926cbb35d3486d1d