### PR TITLE
Add terms pages and sequential modal

### DIFF
--- a/src/components/TermsModal.tsx
+++ b/src/components/TermsModal.tsx
@@ -22,31 +22,53 @@ export function TermsModal({ onAccept }: TermsModalProps) {
             checked={responsibility}
             onChange={(e) => setResponsibility(e.target.checked)}
           />
-          <span>Isenção de responsabilidades (termo em construção)</span>
+          <span>
+            Li e concordo com a{' '}
+            <a className="underline" href="/terms/disclaimer" target="_blank" rel="noopener noreferrer">
+              Isenção de responsabilidade
+            </a>
+          </span>
         </label>
-        <label className="flex items-start space-x-2 text-gray-200">
-          <input
-            type="checkbox"
-            className="mt-1"
-            checked={useTerms}
-            onChange={(e) => setUseTerms(e.target.checked)}
-          />
-          <span>Termos de uso (em breve)</span>
-        </label>
-        <label className="flex items-start space-x-2 text-gray-200">
-          <input
-            type="checkbox"
-            className="mt-1"
-            checked={serviceTerms}
-            onChange={(e) => setServiceTerms(e.target.checked)}
-          />
-          <span>Termos de serviço (em breve)</span>
-        </label>
+
+        {responsibility && (
+          <label className="flex items-start space-x-2 text-gray-200 justify-end">
+            <input
+              type="checkbox"
+              className="mt-1"
+              checked={useTerms}
+              onChange={(e) => setUseTerms(e.target.checked)}
+            />
+            <span>
+              Li e aceito os{' '}
+              <a className="underline" href="/terms/termos-de-uso" target="_blank" rel="noopener noreferrer">
+                Termos de Uso
+              </a>
+            </span>
+          </label>
+        )}
+
+        {responsibility && useTerms && (
+          <label className="flex items-start space-x-2 text-gray-200 justify-end">
+            <input
+              type="checkbox"
+              className="mt-1"
+              checked={serviceTerms}
+              onChange={(e) => setServiceTerms(e.target.checked)}
+            />
+            <span>
+              Li e aceito os{' '}
+              <a className="underline" href="/terms/termos-de-servico" target="_blank" rel="noopener noreferrer">
+                Termos de Serviço
+              </a>
+            </span>
+          </label>
+        )}
+
         <button
           disabled={!allChecked}
           onClick={onAccept}
           className={`w-full py-2 rounded text-white ${
-            allChecked ? "bg-blue-600" : "bg-gray-600 cursor-not-allowed"
+            allChecked ? 'bg-blue-600' : 'bg-gray-600 cursor-not-allowed'
           }`}
         >
           Aceitar

--- a/src/pages/terms/disclaimer.tsx
+++ b/src/pages/terms/disclaimer.tsx
@@ -1,0 +1,31 @@
+import Head from 'next/head'
+
+export default function Disclaimer() {
+  return (
+    <>
+      <Head>
+        <title>Isenção de responsabilidade - Hydra Theme Editor</title>
+      </Head>
+      <div className="max-w-2xl mx-auto p-8 space-y-4 bg-white text-gray-800">
+        <h1 className="text-2xl font-bold">Isenção de responsabilidade</h1>
+        <p>
+          O Hydra Theme Editor é fornecido &quot;no estado em que se encontra&quot; como
+          uma ferramenta experimental para personalização de temas do
+          aplicativo Hydra. Nenhuma garantia é oferecida quanto ao
+          funcionamento da ferramenta ou à adequação dos temas gerados.
+        </p>
+        <p>
+          Ao utilizar o editor você reconhece que todo e qualquer impacto no
+          funcionamento do Hydra ou de softwares associados é de sua
+          exclusiva responsabilidade. Os mantenedores do projeto não se
+          responsabilizam por perdas, danos ou prejuízos decorrentes da
+          utilização do editor ou dos temas criados.
+        </p>
+        <p>
+          Caso não esteja de acordo com estes termos, não utilize o Hydra Theme
+          Editor.
+        </p>
+      </div>
+    </>
+  )
+}

--- a/src/pages/terms/termos-de-servico.tsx
+++ b/src/pages/terms/termos-de-servico.tsx
@@ -1,0 +1,28 @@
+import Head from 'next/head'
+
+export default function TermosDeServico() {
+  return (
+    <>
+      <Head>
+        <title>Termos de Serviço - Hydra Theme Editor</title>
+      </Head>
+      <div className="max-w-2xl mx-auto p-8 space-y-4 bg-white text-gray-800">
+        <h1 className="text-2xl font-bold">Termos de Serviço</h1>
+        <p>
+          Os Termos de Serviço regulam o acesso e a prestação dos recursos
+          oferecidos pelo Hydra Theme Editor. Ao continuar utilizando o editor,
+          você concorda com estas condições.
+        </p>
+        <p>
+          Os desenvolvedores poderão modificar ou descontinuar o editor a
+          qualquer momento, sem notificação prévia. Não há garantia de
+          disponibilidade ou de suporte técnico.
+        </p>
+        <p>
+          Estes Termos de Serviço são complementares aos Termos de Uso e à
+          Isenção de Responsabilidade.
+        </p>
+      </div>
+    </>
+  )
+}

--- a/src/pages/terms/termos-de-uso.tsx
+++ b/src/pages/terms/termos-de-uso.tsx
@@ -1,0 +1,29 @@
+import Head from 'next/head'
+
+export default function TermosDeUso() {
+  return (
+    <>
+      <Head>
+        <title>Termos de Uso - Hydra Theme Editor</title>
+      </Head>
+      <div className="max-w-2xl mx-auto p-8 space-y-4 bg-white text-gray-800">
+        <h1 className="text-2xl font-bold">Termos de Uso</h1>
+        <p>
+          Este documento descreve as condições para utilização do Hydra Theme
+          Editor. Ao utilizar a ferramenta, você concorda em respeitar todos os
+          termos aqui estabelecidos.
+        </p>
+        <p>
+          O editor destina-se apenas à criação e experimentação de temas do
+          aplicativo Hydra. É proibida a utilização da ferramenta para fins
+          ilegais ou que violem direitos de terceiros.
+        </p>
+        <p>
+          O código e os temas produzidos através do Hydra Theme Editor podem ser
+          utilizados livremente, desde que mantidos os devidos créditos aos
+          autores originais e ao projeto.
+        </p>
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- add Isenção de responsabilidade, Termos de Uso and Termos de Serviço pages
- update `TermsModal` with sequential acceptance flow and links

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities and other pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6840d196fb788331b12f32599cb70d8b