### PR TITLE
Use Shadcn style dialog

### DIFF
--- a/src/components/TermsModal.tsx
+++ b/src/components/TermsModal.tsx
@@ -1,4 +1,10 @@
 import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 
 interface TermsModalProps {
   onAccept: () => void;
@@ -12,11 +18,11 @@ export function TermsModal({ onAccept }: TermsModalProps) {
   const allChecked = responsibility && useTerms && serviceTerms;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-80">
-      <div className="bg-gray-800 p-6 rounded space-y-4 max-w-md w-full flex flex-col items-baseline">
-        <h2 className="text-lg font-semibold text-white">
-          Confirmação de Termos
-        </h2>
+    <Dialog open onOpenChange={() => {}}>
+      <DialogContent className="space-y-4 flex flex-col items-baseline">
+        <DialogHeader>
+          <DialogTitle className="text-white">Confirmação de Termos</DialogTitle>
+        </DialogHeader>
         <label className="flex items-start space-x-2 text-gray-200">
           <input
             type="checkbox"
@@ -90,7 +96,7 @@ export function TermsModal({ onAccept }: TermsModalProps) {
         >
           Aceitar
         </button>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import * as React from 'react'
+import { Dialog as HeadlessDialog, Transition } from '@headlessui/react'
+import { Fragment } from 'react'
+
+import { cn } from '@/lib/utils'
+
+export interface DialogProps {
+  open: boolean
+  onOpenChange(open: boolean): void
+  children: React.ReactNode
+}
+
+export function Dialog({ open, onOpenChange, children }: DialogProps) {
+  return (
+    <Transition appear show={open} as={Fragment}>
+      <HeadlessDialog as="div" className="relative z-50" onClose={onOpenChange}>
+        {children}
+      </HeadlessDialog>
+    </Transition>
+  )
+}
+
+export const DialogContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, children, ...props }, ref) => (
+    <div className="fixed inset-0 flex items-center justify-center bg-black/80">
+      <div
+        ref={ref}
+        className={cn('bg-gray-800 p-6 sm:rounded-lg space-y-4', className)}
+        {...props}
+      >
+        {children}
+      </div>
+    </div>
+  )
+)
+DialogContent.displayName = 'DialogContent'
+
+export const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />
+)
+DialogHeader.displayName = 'DialogHeader'
+
+export const DialogTitle = React.forwardRef<HTMLHeadingElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <HeadlessDialog.Title ref={ref} className={cn('text-lg font-semibold text-white', className)} {...props} />
+  )
+)
+DialogTitle.displayName = 'DialogTitle'
+
+export const DialogDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => (
+    <HeadlessDialog.Description ref={ref} className={cn('text-sm text-gray-200', className)} {...props} />
+  )
+)
+DialogDescription.displayName = 'DialogDescription'
+

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: Array<string | undefined | null | false>): string {
+  return classes.filter(Boolean).join(' ');
+}


### PR DESCRIPTION
## Summary
- refactor `TermsModal` to use a Dialog component
- add simple Dialog implementation under `components/ui`
- add helper `cn` utility

## Testing
- `npm run lint`
- `npm run build` *(fails: Type error in existing file)*

------
https://chatgpt.com/codex/tasks/task_e_6840d87a5f188331a8e9b1264b5c8dd7