### PR TITLE
Fix NextAuth session typing

### DIFF
--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -32,7 +32,6 @@ export const authOptions: NextAuthOptions = {
     // 3) Expomos githubToken e githubLogin na session
     async session({ session, token }) {
       session.githubToken = token.githubToken;
-      // @ts-expect-error: user.login is augmented in next-auth types
       session.user.login = token.githubLogin;
       return session;
     },

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,5 +1,6 @@
 // src/types/next-auth.d.ts
 import "next-auth";
+import "next-auth/jwt";
 
 declare module "next-auth" {
   interface Session {
@@ -15,6 +16,13 @@ declare module "next-auth" {
   }
   interface JWT {
     // campos que inserimos no jwt callback
+    githubToken?: string;
+    githubLogin?: string;
+  }
+}
+
+declare module "next-auth/jwt" {
+  interface JWT {
     githubToken?: string;
     githubLogin?: string;
   }


### PR DESCRIPTION
## Summary
- patch NextAuth type augmentations so JWT and session types include custom fields
- remove outdated ts-expect-error comment in auth API handler

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840e033c7488331901f75d172415658