### PR TITLE
Implement Hydra featured API proxy

### DIFF
--- a/src/components/HydraMock.tsx
+++ b/src/components/HydraMock.tsx
@@ -158,7 +158,7 @@ export const HydraMock = forwardRef<HTMLDivElement, HydraMockProps>(
     const [game, setGame] = useState<TrendingGame | null>(null);
 
     useEffect(() => {
-      fetch('https://hydra-api-us-east-1.losbroxas.org/games/featured')
+      fetch('/api/hydra/featured')
         .then((res) => res.json())
         .then((data: TrendingGame[]) => {
           if (Array.isArray(data) && data.length) {

--- a/src/pages/api/hydra/featured.ts
+++ b/src/pages/api/hydra/featured.ts
@@ -1,0 +1,15 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const response = await fetch('https://hydra-api-us/games/featured');
+    if (!response.ok) {
+      return res.status(response.status).json({ error: 'Failed to fetch Hydra data' });
+    }
+    const data = await response.json();
+    res.status(200).json(data);
+  } catch (err) {
+    console.error('Error fetching Hydra data:', err);
+    res.status(500).json({ error: 'Internal error' });
+  }
+}


### PR DESCRIPTION
## Summary
- add Next.js API route to fetch featured games from `https://hydra-api-us`
- use the internal `/api/hydra/featured` route in `HydraMock`

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840ee2d56c48331a408743dac5342ab