### PR TITLE
Add Google Analytics integration

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -15,3 +15,6 @@ GITHUB_UPSTREAM_OWNER=
 
 # Nome exato do repositório no seu usuário
 GITHUB_UPSTREAM_REPO=
+
+# Identificador do Google Analytics 4 (Measurement ID)
+NEXT_PUBLIC_GA_MEASUREMENT_ID=

--- a/src/components/GoogleAnalytics.tsx
+++ b/src/components/GoogleAnalytics.tsx
@@ -1,0 +1,34 @@
+// src/components/GoogleAnalytics.tsx
+// Componente isolado para inserção do Google Analytics 4.
+// Toda a lógica está devidamente comentada em português para facilitar o entendimento.
+
+import Script from 'next/script';
+import { GA_MEASUREMENT_ID } from '@/lib/analytics';
+
+export function GoogleAnalytics() {
+  // Caso o identificador não esteja definido, não renderizamos nada.
+  if (!GA_MEASUREMENT_ID) {
+    return null;
+  }
+
+  return (
+    <>
+      {/* Carrega o script principal do Google Analytics de forma assíncrona */}
+      <Script
+        id="ga-externo"
+        src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+        strategy="afterInteractive"
+      />
+
+      {/* Bloco inline necessário para configurar o GA4 */}
+      <Script id="ga-inline" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '${GA_MEASUREMENT_ID}', { page_path: window.location.pathname });
+        `}
+      </Script>
+    </>
+  );
+}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,52 @@
+// src/lib/analytics.ts
+// Arquivo de utilidades para integrar o Google Analytics 4.
+// Toda a implementação está comentada em português de forma detalhada.
+
+// Identificador de medição do GA4. Ele é exposto no lado do cliente por
+// meio da variável de ambiente "NEXT_PUBLIC_GA_MEASUREMENT_ID". Essa
+// configuração permite que o código permaneça limpo e que o identificador
+// seja alterado sem mexer no código fonte.
+export const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID ?? '';
+
+// Registra uma visualização de página. É chamada toda vez que o usuário
+// muda de rota dentro da aplicação.
+export function pageview(url: string): void {
+  // Verifica se estamos no ambiente do navegador e se o ID de medição foi
+  // configurado. Caso contrário, não faz nada.
+  if (typeof window === 'undefined' || !GA_MEASUREMENT_ID) {
+    return;
+  }
+
+  // A função "gtag" é disponibilizada pelo script do Google Analytics e
+  // utilizada para enviar eventos. Aqui configuramos o tipo "config" para
+  // registrar a visualização de página.
+  window.gtag('config', GA_MEASUREMENT_ID, {
+    page_path: url,
+  });
+}
+
+// Dispara um evento personalizado. Pode ser utilizado para rastrear ações
+// específicas do usuário (cliques, downloads, etc.).
+export function event({
+  action,
+  category,
+  label,
+  value,
+}: {
+  action: string;
+  category: string;
+  label: string;
+  value?: number;
+}): void {
+  if (typeof window === 'undefined' || !GA_MEASUREMENT_ID) {
+    return;
+  }
+
+  // O método "gtag" recebe o nome do evento (action) e os parâmetros
+  // adicionais de categorização.
+  window.gtag('event', action, {
+    event_category: category,
+    event_label: label,
+    value,
+  });
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -4,11 +4,32 @@ import "@/styles/HydraMock.css";
 import type { AppProps } from "next/app";
 import { SessionProvider } from "next-auth/react";
 import type { Session } from "next-auth";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
 import { Navbar } from "@/components/Navbar";
+import { GoogleAnalytics } from "@/components/GoogleAnalytics";
+import * as analytics from "@/lib/analytics";
 
 export default function App({ Component, pageProps }: AppProps<{ session: Session | null }>) {
+  const router = useRouter();
+
+  // Toda vez que a rota mudar, registramos a visualização no Google Analytics
+  useEffect(() => {
+    const handleRouteChange = (url: string) => {
+      analytics.pageview(url);
+    };
+
+    router.events.on('routeChangeComplete', handleRouteChange);
+    return () => {
+      router.events.off('routeChangeComplete', handleRouteChange);
+    };
+  }, [router.events]);
+
   return (
     <SessionProvider session={pageProps.session}>
+      {/* Componente responsável por carregar o script do Google Analytics */}
+      <GoogleAnalytics />
+
       {/* 1) Navbar sempre visível */}
       <Navbar />
 

--- a/src/types/gtag.d.ts
+++ b/src/types/gtag.d.ts
@@ -1,0 +1,5 @@
+// src/types/gtag.d.ts
+// Declaração do método global `gtag` utilizado pelo Google Analytics.
+interface Window {
+  gtag(...args: unknown[]): void;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,8 @@
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
-    "src/types/next-auth.d.ts"
+    "src/types/next-auth.d.ts",
+    "src/types/gtag.d.ts"
   ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- add GA measurement ID placeholder to `.env-example`
- add Google Analytics helper functions
- load GA script via new `GoogleAnalytics` component
- track route changes in `_app.tsx`
- declare global `gtag` type
- include custom type file in `tsconfig.json`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68437821b5bc8331908c17bacdec3dc1