### PR TITLE
Populate hot games grid

### DIFF
--- a/src/components/HydraMock.tsx
+++ b/src/components/HydraMock.tsx
@@ -156,6 +156,7 @@ function scopeCss(css: string): string {
 export const HydraMock = forwardRef<HTMLDivElement, HydraMockProps>(
   ({ customCss }, ref) => {
     const [game, setGame] = useState<TrendingGame | null>(null);
+    const [hotGames, setHotGames] = useState<TrendingGame[]>([]);
 
     useEffect(() => {
       fetch('/api/hydra/featured')
@@ -163,6 +164,17 @@ export const HydraMock = forwardRef<HTMLDivElement, HydraMockProps>(
         .then((data: TrendingGame[]) => {
           if (Array.isArray(data) && data.length) {
             setGame(data[0]);
+          }
+        })
+        .catch(() => {
+          // ignora erros silenciosamente
+        });
+
+      fetch('/api/hydra/hot')
+        .then((res) => res.json())
+        .then((data: TrendingGame[]) => {
+          if (Array.isArray(data)) {
+            setHotGames(data);
           }
         })
         .catch(() => {
@@ -373,10 +385,31 @@ export const HydraMock = forwardRef<HTMLDivElement, HydraMockProps>(
 
                 {/* Grid de cards de jogos */}
                 <section className="settings-appearance__themes grid grid-cols-2 gap-4 home__cards">
-                  <div className="theme-card bg-gray-700 rounded h-36 home__card-skeleton"></div>
-                  <div className="theme-card bg-gray-700 rounded h-36 home__card-skeleton"></div>
-                  <div className="theme-card bg-gray-700 rounded h-36 home__card-skeleton"></div>
-                  <div className="theme-card bg-gray-700 rounded h-36 home__card-skeleton"></div>
+                  {hotGames.length > 0 ? (
+                    hotGames.map((g) => (
+                      <div
+                        key={g.objectId}
+                        className="theme-card bg-gray-700 rounded h-36 relative overflow-hidden flex items-end"
+                      >
+                        <Image
+                          src={g.libraryImageUrl}
+                          alt={g.title}
+                          fill
+                          className="object-cover"
+                          unoptimized
+                        />
+                        <div className="absolute inset-0 bg-black/40" />
+                        <span className="relative p-2 text-sm">{g.title}</span>
+                      </div>
+                    ))
+                  ) : (
+                    Array.from({ length: 4 }).map((_, i) => (
+                      <div
+                        key={i}
+                        className="theme-card bg-gray-700 rounded h-36 home__card-skeleton"
+                      />
+                    ))
+                  )}
                 </section>
               </section>
             </div>

--- a/src/pages/api/hydra/hot.ts
+++ b/src/pages/api/hydra/hot.ts
@@ -1,0 +1,22 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  try {
+    const response = await fetch(
+      'https://hydra-api-us-east-1.losbroxas.org/catalogue/hot?take=12&skip=0'
+    );
+    if (!response.ok) {
+      return res
+        .status(response.status)
+        .json({ error: 'Failed to fetch Hydra data' });
+    }
+    const data = await response.json();
+    res.status(200).json(data);
+  } catch (err) {
+    console.error('Error fetching Hydra data:', err);
+    res.status(500).json({ error: 'Internal error' });
+  }
+}


### PR DESCRIPTION
## Summary
- fetch `catalogue/hot` data from Hydra API
- load hot games in `HydraMock` component
- render game cards using the returned title and library image

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6845c5b2841c833193bebfff605441c8