### PR TITLE
Add uploaded images gallery

### DIFF
--- a/src/components/ThemeEditor.tsx
+++ b/src/components/ThemeEditor.tsx
@@ -3,6 +3,7 @@ import React, { useState, useRef } from 'react';
 import Editor from '@monaco-editor/react';
 import html2canvas from 'html2canvas';
 import { HydraMock } from './HydraMock';
+import { UploadedImages } from './UploadedImages';
 import type { OnMount } from '@monaco-editor/react';
 import classDescriptions from '@/data/classDescriptions';
 
@@ -179,6 +180,7 @@ export function ThemeEditor() {
             {loading ? 'Enviando PR…' : 'Create PR'}
           </button>
         </div>
+        <UploadedImages />
       </div>
 
       {/* Preview Mock */}

--- a/src/components/UploadedImages.tsx
+++ b/src/components/UploadedImages.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react';
+
+interface UploadedImage {
+  id: string;
+  url: string;
+  thumbUrl: string;
+  size: number;
+  extension: string;
+}
+
+export function UploadedImages() {
+  const [images, setImages] = useState<UploadedImage[]>([]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const stored = localStorage.getItem('uploadedImages');
+      if (stored) {
+        setImages(JSON.parse(stored));
+      }
+    } catch {
+      setImages([]);
+    }
+  }, []);
+
+  if (!images.length) return null;
+
+  return (
+    <div>
+      <h3 className="text-sm font-semibold mb-2">Uploads Recentes</h3>
+      <div className="grid grid-cols-3 gap-2">
+        {images.map((img) => (
+          <a
+            key={img.id}
+            href={img.url}
+            target="_blank"
+            rel="noreferrer"
+            className="border p-1 text-center text-xs space-y-1 rounded"
+          >
+            <img
+              src={img.thumbUrl}
+              alt="thumbnail"
+              className="w-full h-20 object-cover"
+            />
+            <div>{(img.size / 1024).toFixed(1)}KB</div>
+            <div>.{img.extension}</div>
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/upload.tsx
+++ b/src/pages/upload.tsx
@@ -40,6 +40,21 @@ export default function Upload() {
         if (data?.data?.display_url) {
           setUrl(data.data.display_url);
           setError('');
+          try {
+            const stored = JSON.parse(
+              localStorage.getItem('uploadedImages') || '[]'
+            );
+            stored.push({
+              id: data.data.id,
+              url: data.data.display_url,
+              thumbUrl: data.data.thumb.url,
+              size: data.data.size,
+              extension: data.data.image.extension,
+            });
+            localStorage.setItem('uploadedImages', JSON.stringify(stored));
+          } catch {
+            /* ignore */
+          }
         } else {
           setError('Falha ao enviar a imagem.');
           setUrl('');


### PR DESCRIPTION
## Summary
- keep uploaded image data in localStorage
- show uploaded images near the editor in a grid

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6858a26b1d0483319baab33853cfb219